### PR TITLE
santoni: configs: manifest: Use passthrough for camera provider hidl

### DIFF
--- a/configs/manifests/manifest.xml
+++ b/configs/manifests/manifest.xml
@@ -16,7 +16,7 @@
     </hal>
     <hal format="hidl">
         <name>android.hardware.camera.provider</name>
-        <transport>hwbinder</transport>
+        <transport arch="32+64">passthrough</transport>
         <fqname>@2.4::ICameraProvider/legacy/0</fqname>
     </hal>
     <hal format="hidl">


### PR DESCRIPTION
E/LegacySupport(6972): Could not get passthrough implementation for android.hardware.camera.provider@2.4::ICameraProvider/legacy/0